### PR TITLE
サイドバーにグループメッセージを表示させる

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,12 @@ class Group < ApplicationRecord
   has_many :messages
   
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.content : '画像が投稿されています。'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -14,7 +14,7 @@
     - current_user.groups.each do |group|
       .group
         = link_to group_messages_path(group) do
-          %p.group__group-name<
+          .group__group-name<
             = group.name
-          %p.group__latast-message<
-            メッセージはまだありません。
+          .group__latast-message<
+            = group.show_last_message


### PR DESCRIPTION
# What
サイドバーのグループ名の下にそのメッセージの最新のものを表示させる。
# Why
グループの最新の状況をわかりやすくするため。