### PR TITLE
チャット画面のヘッダーにグループ名を表示させる

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,7 +7,7 @@ class Group < ApplicationRecord
 
   def show_last_message
     if (last_message = messages.last).present?
-      last_message.body? ? last_message.content : '画像が投稿されています。'
+      last_message.body? ? last_message.body : '画像が投稿されています。'
     else
       'まだメッセージはありません。'
     end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -5,8 +5,9 @@
         = @group.name
       %ul.main-header__left-box__member-list
         member:
-        %li.main-header__left-box__member-list__member<
-          member1
+        - @group.group_users.each do |group_user|
+          %li.main-header__left-box__member-list__member<
+            = group_user.user.name
     = link_to "#" do
       .main-header__edit-btn
         Edit

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,7 +2,7 @@
   .main-header
     .main-header__left-box
       %h2.main-header__left-box__current-group
-        group-name1
+        = @group.name
       %ul.main-header__left-box__member-list
         member:
         %li.main-header__left-box__member-list__member<


### PR DESCRIPTION
# What
メインチャット画面のヘッダー部にグループ名とメンバー名を表示させる。
# Why
表示させることによってどこのグループで、誰とチャットしているのかが分かりやすくなる。