### PR TITLE
グループ編集後のリダイレクト先を変更する

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -23,7 +23,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end


### PR DESCRIPTION
# What
グループ編集後のリダイレクト先を現在のメッセージ一覧ページに変更する。
# Why
編集後にいちいちトップページ戻るのは面倒なため。