### PR TITLE
検索機能の強化

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -29,16 +29,20 @@ $(function() {
   }
 
   function addMember(userId) {
-    let html = `<input value="${userId}" name="group[user_ids][]" type="hidden" id="group_user_ids_${userId}" />`;
+    let html = `<input value="${userId}" name="group[user_ids][]" type="hidden" class="js-chat-member__id" />`;
     $(`#${userId}`).append(html);
   }
 
   $("#user-search-field").on("keyup", function() {
     let input = $("#user-search-field").val();
+    let memberId = $(".js-chat-member__id").map(function(){
+      return $(this).val();
+    }).get();
+
     $.ajax({
       type: 'GET',
       url: '/users',
-      data: { keyword: input },
+      data: { keyword: input, id: memberId },
       dataType: 'json'
     })
     .done(function(users) {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.search(params[:keyword], current_user.id)
+    @users = User.search(params[:keyword], params[:id])
     respond_to do |format|
       format.html
       format.json

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
 
   def self.search(input, id)
     return nil if input == ""
-    User.where(['name LIKE ?', "%#{input}%"]).where.not(id: id).limit(10)
+    User.where.not(id: id).where(['name LIKE ?', "%#{input}%"]).limit(10)
   end
 
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -24,13 +24,13 @@
     .chat-group-form__field--right
       #chat-group-users.js-add-user
         .chat-group-user.clearfix.js-chat-member
-          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %input{name: "group[user_ids][]", class: "js-chat-member__id", type: "hidden", value: current_user.id}
           %p.chat-group-user__name
             = current_user.name
         - group.users.each do |user|
           - if current_user.name != user.name
             .chat-group-user.clearfix.js-chat-member
-              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %input{name: "group[user_ids][]", class: "js-chat-member__id", type: "hidden", value: user.id}
               %p.chat-group-user__name
                 = user.name
               %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn


### PR DESCRIPTION
# What
インクリメンタルサーチに機能を追加した。
チャットメンバーに追加すると以後検索結果から除外されるようにした。逆にメンバー登録済みユーザーから外すと検索にかかるようにした。
# Why
検索・メンバー追加後も追加済みユーザーが検索結果に出てしまうと混乱を招くため。